### PR TITLE
Potential fix for code scanning alert no. 7: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/recategorize-discussions.yml
+++ b/.github/workflows/recategorize-discussions.yml
@@ -2,6 +2,10 @@
 
 name: Recategorize labeled discussions
 
+permissions:
+  contents: read
+  discussions: write
+
 # Controls when the action will run. Workflow runs when manually triggered using the UI
 # or API.
 on:


### PR DESCRIPTION
Potential fix for [https://github.com/roseteromeo56-cb-id/community/security/code-scanning/7](https://github.com/roseteromeo56-cb-id/community/security/code-scanning/7)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will specify the minimal permissions required for the workflow to function correctly. Based on the workflow's operations:
- It needs `contents: read` to access repository contents.
- It needs `discussions: write` to move discussions to a new category.

The `permissions` block will be added at the root level, applying to all jobs in the workflow.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
