### PR TITLE
Potential fix for code scanning alert no. 6: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/remove-governed-labels-on-create.yml
+++ b/.github/workflows/remove-governed-labels-on-create.yml
@@ -5,6 +5,10 @@ on:
   discussion:
     types: [created]
 
+permissions:
+  contents: read
+  discussions: write
+
 jobs:
   check_labels:
     name: Check labels


### PR DESCRIPTION
Potential fix for [https://github.com/roseteromeo56-cb-id/community/security/code-scanning/6](https://github.com/roseteromeo56-cb-id/community/security/code-scanning/6)

To fix the issue, we will add a `permissions` block to the workflow. This block will define the minimal permissions required for the workflow to function correctly. Based on the workflow's steps:
1. The `contents: read` permission is needed to fetch repository data.
2. The `discussions: write` permission is required to modify discussions (e.g., removing labels).

The `permissions` block will be added at the workflow level (root) to apply to all jobs, as all steps in the workflow use the `GITHUB_TOKEN`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
