### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/label-templated-discussions.yml
+++ b/.github/workflows/label-templated-discussions.yml
@@ -4,6 +4,10 @@ on:
   discussion:
     types: [created]
 
+permissions:
+  discussions: write
+  contents: read
+
 jobs:
   label-templated-discussion:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/roseteromeo56-cb-id/community/security/code-scanning/5](https://github.com/roseteromeo56-cb-id/community/security/code-scanning/5)

To fix the issue, we will add a `permissions` block at the root of the workflow file to explicitly define the required permissions. Based on the workflow's functionality:
- `discussions: write` is needed to interact with discussions (e.g., fetching discussion details and labeling discussions).
- `contents: read` is needed to access repository contents.

This ensures the workflow has only the permissions it needs and no more.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
