### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/generator-generic-ossf-slsa3-publish.yml
+++ b/.github/workflows/generator-generic-ossf-slsa3-publish.yml
@@ -11,6 +11,8 @@
 # For more information about SLSA and how it improves the supply-chain, visit slsa.dev.
 
 name: SLSA generic generator
+permissions:
+  contents: read
 on:
   workflow_dispatch:
   release:


### PR DESCRIPTION
Potential fix for [https://github.com/roseteromeo56-cb-id/community/security/code-scanning/4](https://github.com/roseteromeo56-cb-id/community/security/code-scanning/4)

To fix the issue, we will add a `permissions` block at the root level of the workflow to define the least privileges required for all jobs. Since the `build` job does not require write permissions, we will set `contents: read` at the root level. The `provenance` job already has its own `permissions` block, so it will remain unchanged.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
