### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/issue_projects_labeler.yml
+++ b/.github/workflows/issue_projects_labeler.yml
@@ -1,5 +1,10 @@
 name: Issue and Project Templated Discussions
 
+permissions:
+  contents: read
+  discussions: write
+  repository-projects: read
+
 on:
   discussion:
     types: [created]


### PR DESCRIPTION
Potential fix for [https://github.com/roseteromeo56-cb-id/community/security/code-scanning/3](https://github.com/roseteromeo56-cb-id/community/security/code-scanning/3)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will specify the minimal permissions required for the workflow to function correctly. Based on the workflow's operations, it needs the following permissions:
- `contents: read` to access repository contents.
- `discussions: read` to fetch discussion data.
- `discussions: write` to label discussions.
- `repository-projects: read` to interact with repository projects (if applicable).

The `permissions` block will be added at the top level of the workflow, ensuring it applies to all jobs unless overridden by job-specific permissions.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
