### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/copilot_labeller.yml
+++ b/.github/workflows/copilot_labeller.yml
@@ -4,6 +4,10 @@ on:
   discussion:
     types: [created]
 
+permissions:
+  contents: read
+  discussions: write
+
 jobs:
   label-copilot-discussion:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/roseteromeo56-cb-id/community/security/code-scanning/2](https://github.com/roseteromeo56-cb-id/community/security/code-scanning/2)

To fix the issue, we will add a `permissions` block at the workflow level to explicitly define the least privileges required for the `GITHUB_TOKEN`. Based on the operations in the workflow, the following permissions are needed:
- `contents: read` for accessing repository contents.
- `discussions: read` for reading discussion data.
- `discussions: write` for labeling discussions.

The `permissions` block will be added at the root level of the workflow to apply to all jobs.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
