### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/Accessibility-Labeler.yml
+++ b/.github/workflows/Accessibility-Labeler.yml
@@ -4,6 +4,10 @@ on:
   discussion:
     types: [created]
 
+permissions:
+  contents: read
+  discussions: write
+
 jobs:
   label-templated-discussion:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/roseteromeo56-cb-id/community/security/code-scanning/1](https://github.com/roseteromeo56-cb-id/community/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the workflow level to explicitly define the least privileges required. Based on the operations in the workflow, the following permissions are needed:
- `contents: read` to access repository contents.
- `discussions: read` to fetch discussion data.
- `discussions: write` to add labels to discussions.

The `permissions` block will be added at the root of the workflow file, ensuring it applies to all jobs in the workflow.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
